### PR TITLE
Add `msgspec` to the benchmarks

### DIFF
--- a/generate_minefield_reports.py
+++ b/generate_minefield_reports.py
@@ -37,6 +37,11 @@ def do_simdjson(content):
     p.parse(content)
 
 
+def do_msgspec(content):
+    import msgspec
+    msgspec.json.decode(content.encode('utf-8'))
+
+
 def run_minefield(do_parse, tests):
     tally = {
         'expected_result': 0,
@@ -54,21 +59,13 @@ def run_minefield(do_parse, tests):
                 try:
                     do_parse(src.read())
                 except Exception:  # noqa
-                    match expected_result:
-                        case 'y':
-                            key = 'should_have_passed'
-                        case 'n':
-                            key = 'expected_result'
-                        case 'i':
-                            key = 'undefined_failed'
+                    key = {'y': 'should_have_passed',
+                           'n': 'expected_result',
+                           'i': 'undefined_failed'}[expected_result]
                 else:
-                    match expected_result:
-                        case 'y':
-                            key = 'expected_result'
-                        case 'n':
-                            key = 'should_have_failed'
-                        case 'i':
-                            key = 'undefined_passed'
+                    key = {'y': 'expected_result',
+                           'n': 'should_have_failed',
+                           'i': 'undefined_passed'}[expected_result]
 
                 results.append((expected_result, file, key))
                 tally[key] += 1
@@ -80,17 +77,11 @@ def run_minefield(do_parse, tests):
 
 
 def label(k) -> str:
-    match k:
-        case 'expected_result':
-            return '🎉 expected result'
-        case 'should_have_passed':
-            return '🔥 parsing should have succeeded but failed'
-        case 'should_have_failed':
-            return '🔥 parsing should have failed but succeeded'
-        case 'undefined_passed':
-            return '➕ result undefined, parsing succeeded'
-        case 'undefined_failed':
-            return '➖ result undefined, parsing failed'
+    return {'expected_result': '🎉 expected result',
+            'should_have_passed': '🔥 parsing should have succeeded but failed',
+            'should_have_failed': '🔥 parsing should have failed but succeeded',
+            'undefined_passed': '➕ result undefined, parsing succeeded',
+            'undefined_failed': '➖ result undefined, parsing failed'}[k]
 
 
 def main(argv):
@@ -107,7 +98,8 @@ def main(argv):
         ('rapidjson', do_rapidjson),
         ('orjson', do_orjson),
         ('simdjson', do_simdjson),
-        ('ujson', do_ujson)
+        ('ujson', do_ujson),
+        ('msgspec', do_msgspec),
     ]
 
     readme_summary = Fragment()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ pytest-benchmark==3.4.1
 python-rapidjson==1.6
 tomli==2.0.1
 ujson==5.2.0
+msgspec==0.6.0
 -e git+git@github.com:TkTech/py_yyjson.git@a628fdd23c318995fb4b70d88f64f79d29bd61b2#egg=yyjson

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,0 +1,23 @@
+import pytest
+
+msgspec = pytest.importorskip('msgspec')
+
+dec = msgspec.json.Decoder()
+
+
+def parse_document(path, content):
+    dec.decode(content)
+
+
+def test_full_document_read(benchmark, sample_json):
+    """
+    Benchmarks the performance of completely reading in a document to a Python
+    object.
+    """
+    path, content = sample_json
+    content = content.encode("utf-8")
+    benchmark.group = f'Complete load of {path}'
+    benchmark.name = 'msgspec'
+    benchmark.extra_info['file'] = path
+    benchmark.extra_info['file_size'] = len(content)
+    benchmark(parse_document, path, content)


### PR DESCRIPTION
First, thanks for setting up a nice repo for benchmarking JSON + Python performance. I stumbled upon this while looking at pysimdjson (from doing a [quick benchmark myself](https://gist.github.com/jcrist/de29815389eaed4eaf5b24fbcfdab5f0)), and thought I'd push up a commit. Feel free to ignore, I recognize that this benchmarks repo is very new :).

This adds `msgspec` (https://github.com/jcrist/msgspec) to the list of repos measured. I also modified the scripts a bit to work on python 3.9 as well (happy to revert if needed). A few assorted comments:

-  `msgspec` doesn't do that well in these tests, because it's mainly optimized for loading json where you already know the schema (a common case for services and apis). I'm not sure if expanding the benchmarks to include another row for msgspec + schema would make sense. With a schema it's [_much_ more performant](https://jcristharif.com/msgspec/benchmarks.html).
- `msgspec` only supports decoding from a bytes-like object, `str` is not supported. I utf-8 encode the `content` as part of the benchmark, AFAICT there should be no harm in that.

Anyway, thanks for starting on this work. If you'd like additional help in any way I'd be happy to contribute.