### PR TITLE
Update msgspec dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pytest-benchmark==3.4.1
 python-rapidjson==1.6
 tomli==2.0.1
 ujson==5.2.0
-msgspec==0.6.0
+msgspec==0.7.0
 yyjson==0.3.1
 json-merge-patch==0.2


### PR DESCRIPTION
Bumps msgspec version to recently released 0.7.0.

I didn't re-render the benchmarks, since I *think* you want to do that on your own machine, but did check that things ran correctly.